### PR TITLE
Fixed using ffmpeg before it's installed on the first run

### DIFF
--- a/streaming_setup.py
+++ b/streaming_setup.py
@@ -492,6 +492,8 @@ def show_services():
 def main():
     global disable_overwrite, rebuild_all
 
+    install_ffmpeg()
+    
     args = parse_arguments()
     if args.version:
         print(f"{__version__}")
@@ -537,8 +539,6 @@ def main():
 
     if args.safe:
         disable_overwrite = True
-
-    install_ffmpeg()
 
     if args.rtsp and not args.rtsp_url:
         rtsp_systemd = Path("/etc/systemd/system/rtsp_server.service")


### PR DESCRIPTION
Functions parse_arguments and prepare_ffmpeg_command get called in main on the first run when ffmpeg may not be installed yet.  This impacts calling shutil.which('ffmpeg') which returns "None", and directly calling ffmpeg within parse_arguments->find_best_device->camera_info:

data = run(
        f"ffmpeg -hide_banner -f video4linux2 -list_formats all -i {device}", shell=True, stdout=PIPE, stderr=PIPE
    )
